### PR TITLE
PrismaClientでリレーションを含めるときはjoinを使うように変更

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -10,7 +10,8 @@ datasource db {
 }
 
 generator client {
-  provider = "prisma-client-js"
+  provider        = "prisma-client-js"
+  previewFeatures = ["relationJoins"]
 }
 
 model User {


### PR DESCRIPTION
Prismaのデフォルトだとリレーションを含めたいときにSQLが別々で実行されるため、JOINを使うようにした
https://www.prisma.io/docs/orm/prisma-client/queries/relation-queries#relation-load-strategies-preview