### PR TITLE
ideas orderByを受け取る方法を間違えていたため修正

### DIFF
--- a/backend/src/common/decorators/isOrderByValid.decorator.ts
+++ b/backend/src/common/decorators/isOrderByValid.decorator.ts
@@ -7,6 +7,7 @@ import {
 } from 'class-validator'
 
 import { OrderByArgs } from '@src/common/dto/orderBy.args'
+import { SORT_ORDER } from '../constants/sortOrder.constant'
 
 @ValidatorConstraint({ async: true })
 class IsOrderByFieldValidConstraint implements ValidatorConstraintInterface {
@@ -21,8 +22,8 @@ class IsOrderByFieldValidConstraint implements ValidatorConstraintInterface {
   }
 
   defaultMessage(args: ValidationArguments) {
-    const [fields, orders] = args.constraints
-    return `Field must be one of ${fields.join(', ')} and order must be one of ${orders.join(', ')}`
+    const fields = args.constraints
+    return `Field must be one of ${fields.join(', ')} and order must be one of ${Object.values(SORT_ORDER).join(', ')}`
   }
 }
 

--- a/backend/src/common/dto/orderBy.args.ts
+++ b/backend/src/common/dto/orderBy.args.ts
@@ -9,6 +9,6 @@ export class OrderByArgs {
   field: string
 
   @Field()
-  @IsIn(Object.values(SORT_ORDER), { message: `order must be either ${Object.values(SORT_ORDER).join(', ')}` })
+  @IsIn(Object.values(SORT_ORDER), { message: `order must be one of ${Object.values(SORT_ORDER).join(', ')}` })
   order: string
 }

--- a/backend/src/idea/dto/ideasGet.args.ts
+++ b/backend/src/idea/dto/ideasGet.args.ts
@@ -20,8 +20,8 @@ export class IdeasGetArgs {
   @IsIn(Object.values(OPEN_LEVELS), { message: `openLevel must be either ${Object.values(OPEN_LEVELS).join(', ')}` })
   openLevel?: number
 
-  @Field(() => OrderByArgs || [OrderByArgs], { nullable: true })
+  @Field(() => [OrderByArgs], { nullable: true })
   @IsOptional()
   @IsOrderByFieldValid(['id', 'title', 'content', 'openLevel', 'createdAt', 'updatedAt'])
-  orderBy?: OrderByArgs | OrderByArgs[]
+  orderBy?: OrderByArgs[]
 }


### PR DESCRIPTION
- orderByをオブジェクト型と配列型と両方受け取れるような記述をしていたが、実際にはどちらか1パターンしか受け取れないため、配列型に統一
- orderByのバリデーションエラーメッセージ処理がruntime時にjsエラーになってしまうため修正