### PR TITLE
Prismaクライエントのエラーハンドリング修正

### DIFF
--- a/backend/src/prisma/constants/prisma.constant.ts
+++ b/backend/src/prisma/constants/prisma.constant.ts
@@ -1,3 +1,13 @@
+import { SORT_ORDER } from '@src/common/constants/sortOrder.constant'
+
+export const PRISMA_CLIENT_ERROR_NAME = {
+  knownRequestError: 'PrismaClientKnownRequestError',
+  unknownRequestError: 'PrismaClientUnknownRequestError',
+  rustPanicError: 'PrismaClientRustPanicError',
+  initializationError: 'PrismaClientInitializationError',
+  validationError: 'PrismaClientValidationError',
+}
+
 // @see: https://www.prisma.io/docs/orm/reference/error-reference#prisma-client-query-engine
 export const PRISMA_CLIENT_ERROR_CODE = {
   valueTooLong: 'P2000',

--- a/backend/src/prisma/filters/prismaClientException.filter.ts
+++ b/backend/src/prisma/filters/prismaClientException.filter.ts
@@ -2,31 +2,50 @@ import { ArgumentsHost, Catch, ExceptionFilter, HttpException, HttpStatus } from
 import { GqlArgumentsHost } from '@nestjs/graphql'
 import { Prisma } from '@prisma/client'
 
-import { PRISMA_CLIENT_ERROR_CODE } from '../constants/prisma.constant'
+import { customHasOwnProperty } from '@src/common/helpers/customHasOwnProperty.helper'
+import { PRISMA_CLIENT_ERROR_CODE, PRISMA_CLIENT_ERROR_NAME } from '../constants/prisma.constant'
+import { PrismaClientError } from '../types/prisma.type'
 
-@Catch(Prisma.PrismaClientKnownRequestError)
+@Catch(
+  Prisma.PrismaClientKnownRequestError,
+  Prisma.PrismaClientUnknownRequestError,
+  Prisma.PrismaClientRustPanicError,
+  Prisma.PrismaClientInitializationError,
+  Prisma.PrismaClientValidationError,
+)
 export class PrismaClientExceptionFilter implements ExceptionFilter {
+  private readonly ERROR_NAMES_STATUS_MAP = {
+    [PRISMA_CLIENT_ERROR_NAME.knownRequestError]: HttpStatus.INTERNAL_SERVER_ERROR,
+    [PRISMA_CLIENT_ERROR_NAME.unknownRequestError]: HttpStatus.INTERNAL_SERVER_ERROR,
+    [PRISMA_CLIENT_ERROR_NAME.rustPanicError]: HttpStatus.INTERNAL_SERVER_ERROR,
+    [PRISMA_CLIENT_ERROR_NAME.initializationError]: HttpStatus.INTERNAL_SERVER_ERROR,
+    [PRISMA_CLIENT_ERROR_NAME.validationError]: HttpStatus.BAD_REQUEST,
+  } as const
+
   private readonly ERROR_CODES_STATUS_MAP = {
     [PRISMA_CLIENT_ERROR_CODE.valueTooLong]: HttpStatus.BAD_REQUEST,
     [PRISMA_CLIENT_ERROR_CODE.uniqueConstraintFailed]: HttpStatus.CONFLICT,
     [PRISMA_CLIENT_ERROR_CODE.recordsNotFound]: HttpStatus.NOT_FOUND,
+  } as const
+
+  catch(exception: PrismaClientError, host: ArgumentsHost) {
+    return this.handleException(exception, host)
   }
 
-  catch(exception: Prisma.PrismaClientKnownRequestError, host: ArgumentsHost) {
-    if (exception instanceof Prisma.PrismaClientKnownRequestError) {
-      return this.handleException(exception, host)
-    }
-  }
-
-  private handleException(exception: Prisma.PrismaClientKnownRequestError, host: ArgumentsHost) {
+  private handleException(exception: PrismaClientError, host: ArgumentsHost) {
     const gqlHost = GqlArgumentsHost.create(host)
     const isGqlRequest = gqlHost.getContext().req
 
-    const status =
-      exception.code in this.ERROR_CODES_STATUS_MAP
-        ? this.ERROR_CODES_STATUS_MAP[exception.code]
-        : HttpStatus.INTERNAL_SERVER_ERROR
-    const message = `[${exception.code}]: ${this.exceptionShortMessage(exception.message)}`
+    let status: HttpStatus = HttpStatus.INTERNAL_SERVER_ERROR
+
+    if ('code' in exception && customHasOwnProperty(this.ERROR_CODES_STATUS_MAP, exception.code)) {
+      status = this.ERROR_CODES_STATUS_MAP[exception.code]
+    } else if (customHasOwnProperty(this.ERROR_NAMES_STATUS_MAP, exception.name)) {
+      status = this.ERROR_NAMES_STATUS_MAP[exception.name]
+    }
+
+    const prefix = 'code' in exception && exception.code ? `[${exception.code}]: ` : ''
+    const message = `${prefix}${this.exceptionShortMessage(exception.message)}`
     const responseBody = HttpException.createBody(message, exception.name, status)
 
     // GraphQLのリクエストの場合はHttpExceptionをthrowする
@@ -45,6 +64,9 @@ export class PrismaClientExceptionFilter implements ExceptionFilter {
   private exceptionShortMessage(message: string): string {
     const shortMessage = message.substring(message.indexOf('→'))
 
-    return shortMessage.substring(shortMessage.indexOf('\n')).replace(/\n/g, '').trim()
+    return shortMessage
+      .substring(shortMessage.indexOf('\n'))
+      .replace(/\n|\s\s/g, '')
+      .trim()
   }
 }

--- a/backend/src/prisma/types/prisma.type.ts
+++ b/backend/src/prisma/types/prisma.type.ts
@@ -2,6 +2,13 @@ import { Prisma, PrismaClient } from '@prisma/client'
 
 import { CamelCase } from '@src/common/types/string.type'
 
+export type PrismaClientError =
+  | Prisma.PrismaClientKnownRequestError
+  | Prisma.PrismaClientUnknownRequestError
+  | Prisma.PrismaClientRustPanicError
+  | Prisma.PrismaClientInitializationError
+  | Prisma.PrismaClientValidationError
+
 export type ModelDelegateForUpdate = PrismaClient[keyof PrismaClient] & {
   update(args: { where: { id: number }; data: object }): Prisma.PrismaPromise<unknown>
 }


### PR DESCRIPTION
Prismaクライエントのエラーハンドリングが`PrismaClientKnownRequestError`にしか対応していなかったため、その他のエラーにも対応

### 対応したエラー
- PrismaClientKnownRequestError
- PrismaClientUnknownRequestError
- PrismaClientRustPanicError
- PrismaClientInitializationError
- PrismaClientValidationError
