### PR TITLE
ideaにお気に入り機能を追加

### DIFF
--- a/backend/prisma/migrations/20241009155932_add_idea_favorites_table/migration.sql
+++ b/backend/prisma/migrations/20241009155932_add_idea_favorites_table/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "t_idea_favorites" (
+    "id" SERIAL NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "idea_id" INTEGER NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "t_idea_favorites_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "t_idea_favorites_user_id_idea_id_key" ON "t_idea_favorites"("user_id", "idea_id");
+
+-- AddForeignKey
+ALTER TABLE "t_idea_favorites" ADD CONSTRAINT "t_idea_favorites_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "m_users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "t_idea_favorites" ADD CONSTRAINT "t_idea_favorites_idea_id_fkey" FOREIGN KEY ("idea_id") REFERENCES "t_ideas"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -30,8 +30,9 @@ model User {
   pendingEmailChanges PendingEmailChange[]
   ideas               Idea[]
   comments            Comment[]
-  // aiCheckLogs AICheckLog[] // TODO: AIチェック機能を実装するときに有効化する
   reports             Report[]
+  ideaFavorites       IdeaFavorite[]
+  // aiCheckLogs AICheckLog[] // TODO: AIチェック機能を実装するときに有効化する
 
   @@map("m_users")
 }
@@ -66,6 +67,7 @@ model Idea {
   comments       Comment[]
   ideaCategories IdeaCategory[]
   reports        Report[]
+  favorites      IdeaFavorite[]
 
   @@map("t_ideas")
 }
@@ -149,6 +151,19 @@ model ReportReason {
   reports Report[]
 
   @@map("m_report_reasons")
+}
+
+model IdeaFavorite {
+  id        Int      @id @default(autoincrement()) @map("id")
+  userId    Int      @map("user_id")
+  ideaId    Int      @map("idea_id")
+  createdAt DateTime @default(now()) @map("created_at")
+
+  user User @relation(fields: [userId], references: [id])
+  idea Idea @relation(fields: [ideaId], references: [id])
+
+  @@unique([userId, ideaId]) // Ensure a user can only favorite an idea once
+  @@map("t_idea_favorites")
 }
 
 // TODO: AIチェック機能を実装するときに有効化する

--- a/backend/prisma/seed/.snaplet/dataModel.json
+++ b/backend/prisma/seed/.snaplet/dataModel.json
@@ -480,6 +480,20 @@
           "hasDefaultValue": false
         },
         {
+          "name": "t_idea_favorites",
+          "type": "t_idea_favorites",
+          "isRequired": false,
+          "kind": "object",
+          "relationName": "t_idea_favoritesTom_users",
+          "relationFromFields": [],
+          "relationToFields": [],
+          "isList": true,
+          "isId": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false
+        },
+        {
           "name": "t_ideas",
           "type": "t_ideas",
           "isRequired": false,
@@ -809,6 +823,113 @@
         }
       ]
     },
+    "t_idea_favorites": {
+      "id": "public.t_idea_favorites",
+      "schemaName": "public",
+      "tableName": "t_idea_favorites",
+      "fields": [
+        {
+          "id": "public.t_idea_favorites.id",
+          "name": "id",
+          "columnName": "id",
+          "type": "int4",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": {
+            "identifier": "\"public\".\"t_idea_favorites_id_seq\"",
+            "increment": 1,
+            "start": 1
+          },
+          "hasDefaultValue": true,
+          "isId": true,
+          "maxLength": null
+        },
+        {
+          "id": "public.t_idea_favorites.user_id",
+          "name": "user_id",
+          "columnName": "user_id",
+          "type": "int4",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public.t_idea_favorites.idea_id",
+          "name": "idea_id",
+          "columnName": "idea_id",
+          "type": "int4",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public.t_idea_favorites.created_at",
+          "name": "created_at",
+          "columnName": "created_at",
+          "type": "timestamp",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": true,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "name": "m_users",
+          "type": "m_users",
+          "isRequired": true,
+          "kind": "object",
+          "relationName": "t_idea_favoritesTom_users",
+          "relationFromFields": ["user_id"],
+          "relationToFields": ["id"],
+          "isList": false,
+          "isId": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false
+        },
+        {
+          "name": "t_ideas",
+          "type": "t_ideas",
+          "isRequired": true,
+          "kind": "object",
+          "relationName": "t_idea_favoritesTot_ideas",
+          "relationFromFields": ["idea_id"],
+          "relationToFields": ["id"],
+          "isList": false,
+          "isId": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false
+        }
+      ],
+      "uniqueConstraints": [
+        {
+          "name": "t_idea_favorites_pkey",
+          "fields": ["id"],
+          "nullNotDistinct": false
+        },
+        {
+          "name": "t_idea_favorites_user_id_idea_id_key",
+          "fields": ["idea_id", "user_id"],
+          "nullNotDistinct": false
+        }
+      ]
+    },
     "t_idea_files": {
       "id": "public.t_idea_files",
       "schemaName": "public",
@@ -1094,6 +1215,20 @@
           "isRequired": false,
           "kind": "object",
           "relationName": "t_idea_categoriesTot_ideas",
+          "relationFromFields": [],
+          "relationToFields": [],
+          "isList": true,
+          "isId": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false
+        },
+        {
+          "name": "t_idea_favorites",
+          "type": "t_idea_favorites",
+          "isRequired": false,
+          "kind": "object",
+          "relationName": "t_idea_favoritesTot_ideas",
           "relationFromFields": [],
           "relationToFields": [],
           "isList": true,

--- a/backend/prisma/seed/seed.ts
+++ b/backend/prisma/seed/seed.ts
@@ -92,6 +92,7 @@ const main = async () => {
             deletedAt: null,
             t_idea_categories: (createMany) => createMany({ min: 1, max: 3 }, { updatedAt: now }),
             t_idea_files: (createMany) => createMany({ min: 0, max: 5 }, { updatedAt: now }),
+            t_idea_favorites: (createMany) => createMany({ min: 0, max: 5 }),
             t_comments: (createMany) => createMany({ min: 0, max: 5 }, { updatedAt: now, deletedAt: null }),
             t_reports: (createMany) => createMany({ min: 0, max: 5 }, { updatedAt: now }),
           })),

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -8,6 +8,7 @@ import { AuthModule } from './auth/auth.module'
 import { CategoryModule } from './category/category.module'
 import { CommentModule } from './comment/comment.module'
 import { IdeaModule } from './idea/idea.module'
+import { IdeaFavoriteModule } from './ideaFavorite/ideaFavorite.module'
 import { UserModule } from './user/user.module'
 
 @Module({
@@ -21,6 +22,7 @@ import { UserModule } from './user/user.module'
     AuthModule,
     CategoryModule,
     CommentModule,
+    IdeaFavoriteModule,
     IdeaModule,
     UserModule,
   ],

--- a/backend/src/common/types/object.type.ts
+++ b/backend/src/common/types/object.type.ts
@@ -1,0 +1,36 @@
+/*
+ * 指定したプロパティ以外は禁止にする型を作成
+ * 値の型は指定した型になる
+ *
+ * @example
+ * type PartialRecord = StrictPartialRecord<'a' | 'b', string>
+ * const testPartialRecord1: PartialRecord = { a: '' } // OK
+ * const testPartialRecord2: PartialRecord = { a: '', b: '' } // OK
+ * const testPartialRecord3: PartialRecord = { a: '', b: '', c: '' } // NG. 'c' does not exist in type 'Partial<Record<"a" | "b", string>>'.
+ * const testPartialRecord4: PartialRecord = { a: 1 } // NG. Type 'number' is not assignable to type 'string'.
+ */
+export type StrictPartialRecord<K extends string, T = unknown> = Partial<Record<K, T>>
+
+/*
+ * 指定したプロパティを必須かつnullおよびundefinedを許容しない型
+ *
+ * @example
+ * interface Test {
+ *   id: number;
+ *   name?: string | null;
+ *   content?: string | null;
+ * }
+ *
+ * type NewTest = RequiredNonNull<Test, 'name'>;
+ *
+ * This is equal to the following:
+ *
+ * interface NewTest {
+ *  id: number;
+ *  name: string;
+ *  content?: string | null;
+ *  }
+ */
+export type RequiredNonNull<T, K extends keyof T> = Omit<T, K> & {
+  [P in K]-?: NonNullable<T[P]>
+}

--- a/backend/src/idea/constants/idea.constant.ts
+++ b/backend/src/idea/constants/idea.constant.ts
@@ -89,4 +89,15 @@ export const FIELD_RELATIONS: Array<{
       },
     },
   },
+  {
+    field: 'isMyFavorite',
+    relations: {
+      favorites: {
+        where: {
+          // 利用するときにuserIdを置換する処理が必要
+          userId: '%userId%' as unknown as number,
+        },
+      },
+    },
+  },
 ]

--- a/backend/src/idea/constants/idea.constant.ts
+++ b/backend/src/idea/constants/idea.constant.ts
@@ -73,4 +73,20 @@ export const FIELD_RELATIONS: Array<{
       },
     },
   },
+  {
+    field: 'favoritesCount',
+    relations: {
+      _count: {
+        select: {
+          favorites: {
+            where: {
+              idea: {
+                deletedAt: null,
+              },
+            },
+          },
+        },
+      },
+    },
+  },
 ]

--- a/backend/src/idea/idea.resolver.ts
+++ b/backend/src/idea/idea.resolver.ts
@@ -37,7 +37,7 @@ export class IdeaResolver {
     const relations = this.ideaService.createRelations(requestedFields)
 
     if (user) {
-      return await this.ideaService.list({ ideasGetArgs, userId: user?.id }, relations)
+      return await this.ideaService.list({ ideasGetArgs, reporterId: user?.id }, relations)
     }
 
     return await this.ideaService.list({ ideasGetArgs }, relations)
@@ -56,7 +56,7 @@ export class IdeaResolver {
     }
 
     if (user) {
-      return await this.ideaService.count({ ideasGetArgs, userId: user?.id })
+      return await this.ideaService.count({ ideasGetArgs, reporterId: user?.id })
     }
 
     return await this.ideaService.count({ ideasGetArgs })

--- a/backend/src/idea/idea.resolver.ts
+++ b/backend/src/idea/idea.resolver.ts
@@ -58,7 +58,7 @@ export class IdeaResolver {
     if (ideasGetArgs?.includeReportedBySelf === false && user?.id === undefined) {
       throw new CustomBadRequestException([
         {
-          field: 'ideas.argument.includeReportedBySelf',
+          field: 'ideasCount.argument.includeReportedBySelf',
           error: 'Authorization Bearer token is required if includeReportedBySelf argument is false',
         },
       ])
@@ -81,7 +81,7 @@ export class IdeaResolver {
     if (requestedFields.includes('isMyFavorite') && user?.id === undefined) {
       throw new CustomBadRequestException([
         {
-          field: 'ideas.field.isMyFavorite',
+          field: 'idea.field.isMyFavorite',
           error: 'Authorization Bearer token is required if isMyFavorite is requested',
         },
       ])

--- a/backend/src/idea/models/idea.model.ts
+++ b/backend/src/idea/models/idea.model.ts
@@ -46,6 +46,9 @@ export class IdeaRelations {
   @Field(() => Int, { nullable: true })
   favoritesCount?: number | null
 
+  @Field(() => Boolean, { nullable: true })
+  isMyFavorite?: boolean | null
+
   @Field(() => IdeaRelationsCount, { nullable: true })
   _count?: IdeaRelationsCount | null
 }

--- a/backend/src/idea/models/idea.model.ts
+++ b/backend/src/idea/models/idea.model.ts
@@ -4,6 +4,7 @@ import { IsIn } from 'class-validator'
 import { Category } from '@src/category/models/category.model'
 import { Comment } from '@src/comment/models/comment.model'
 import { IdeaCategory } from '@src/ideaCategory/models/ideaCategory.model'
+import { IdeaFavorite } from '@src/ideaFavorite/models/ideaFavorite.model'
 import { User } from '@src/user/models/user.model'
 import { OPEN_LEVELS } from '../constants/idea.constant'
 
@@ -14,6 +15,9 @@ export class IdeaRelationsCount {
 
   @Field(() => Int)
   reports?: number
+
+  @Field(() => Int)
+  favorites?: number
 }
 
 @ObjectType()
@@ -35,6 +39,12 @@ export class IdeaRelations {
 
   @Field(() => [Category], { nullable: true })
   categories?: Category[] | null
+
+  @Field(() => [IdeaFavorite], { nullable: true })
+  favorites?: IdeaFavorite[] | null
+
+  @Field(() => Int, { nullable: true })
+  favoritesCount?: number | null
 
   @Field(() => IdeaRelationsCount, { nullable: true })
   _count?: IdeaRelationsCount | null

--- a/backend/src/ideaFavorite/ideaFavorite.module.ts
+++ b/backend/src/ideaFavorite/ideaFavorite.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common'
+import { PrismaModule } from '@src/prisma/prisma.module'
+import { IdeaFavoriteResolver } from './ideaFavorite.resolver'
+import { IdeaFavoriteService } from './ideaFavorite.service'
+
+@Module({
+  imports: [PrismaModule],
+  providers: [IdeaFavoriteService, IdeaFavoriteResolver],
+})
+export class IdeaFavoriteModule {}

--- a/backend/src/ideaFavorite/ideaFavorite.resolver.ts
+++ b/backend/src/ideaFavorite/ideaFavorite.resolver.ts
@@ -1,0 +1,31 @@
+import { UseGuards } from '@nestjs/common'
+import { Args, Int, Mutation, Resolver } from '@nestjs/graphql'
+
+import { AuthenticatedUser } from '@src/auth/decorators/currentUser.decorator'
+import { JwtAuthGuard } from '@src/auth/guards/jwtAuth.guard'
+import { User } from '@src/user/models/user.model'
+import { IdeaFavoriteService } from './ideaFavorite.service'
+import { IdeaFavorite } from './models/ideaFavorite.model'
+
+@Resolver()
+export class IdeaFavoriteResolver {
+  constructor(private favoriteService: IdeaFavoriteService) {}
+
+  @Mutation(() => IdeaFavorite)
+  @UseGuards(JwtAuthGuard)
+  async createIdeaFavorite(
+    @Args('ideaId', { type: () => Int }) ideaId: number,
+    @AuthenticatedUser() user: User,
+  ): Promise<IdeaFavorite> {
+    return await this.favoriteService.create(ideaId, user.id)
+  }
+
+  @Mutation(() => Boolean)
+  @UseGuards(JwtAuthGuard)
+  async deleteIdeaFavorite(
+    @Args('ideaId', { type: () => Int }) ideaId: number,
+    @AuthenticatedUser() user: User,
+  ): Promise<boolean> {
+    return await this.favoriteService.delete(ideaId, user.id)
+  }
+}

--- a/backend/src/ideaFavorite/ideaFavorite.service.ts
+++ b/backend/src/ideaFavorite/ideaFavorite.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common'
+
+import { PrismaService } from '@src/prisma/prisma.service'
+import { IdeaFavorite } from './models/ideaFavorite.model'
+
+@Injectable()
+export class IdeaFavoriteService {
+  constructor(private prismaService: PrismaService) {}
+
+  async create(ideaId: number, userId: number): Promise<IdeaFavorite> {
+    return await this.prismaService.client.ideaFavorite.create({
+      data: {
+        ideaId,
+        userId,
+      },
+    })
+  }
+
+  async delete(ideaId: number, userId: number): Promise<boolean> {
+    const deletedIdeaFavorite = await this.prismaService.client.ideaFavorite.delete({
+      where: {
+        userId_ideaId: {
+          userId,
+          ideaId,
+        },
+      },
+    })
+
+    return !!deletedIdeaFavorite
+  }
+}

--- a/backend/src/ideaFavorite/models/ideaFavorite.model.ts
+++ b/backend/src/ideaFavorite/models/ideaFavorite.model.ts
@@ -1,0 +1,28 @@
+import { Field, Int, ObjectType } from '@nestjs/graphql'
+
+import { Idea } from '@src/idea/models/idea.model'
+import { User } from '@src/user/models/user.model'
+
+@ObjectType()
+export class IdeaFavoriteRelations {
+  @Field(() => User, { nullable: true })
+  user?: User | null
+
+  @Field(() => Idea, { nullable: true })
+  idea?: Idea | null
+}
+
+@ObjectType()
+export class IdeaFavorite extends IdeaFavoriteRelations {
+  @Field(() => Int)
+  id: number
+
+  @Field(() => Int)
+  userId: number
+
+  @Field(() => Int)
+  ideaId: number
+
+  @Field()
+  createdAt: Date
+}

--- a/backend/src/schema.gql
+++ b/backend/src/schema.gql
@@ -14,15 +14,6 @@ A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date
 """
 scalar DateTime
 
-type IdeaFavorite {
-  user: User
-  idea: Idea
-  id: Int!
-  userId: Int!
-  ideaId: Int!
-  createdAt: DateTime!
-}
-
 type IdeaCategory {
   category: Category
   id: Int!
@@ -30,6 +21,15 @@ type IdeaCategory {
   categoryId: Int!
   createdAt: DateTime!
   updatedAt: DateTime!
+}
+
+type IdeaFavorite {
+  user: User
+  idea: Idea
+  id: Int!
+  userId: Int!
+  ideaId: Int!
+  createdAt: DateTime!
 }
 
 type IdeaRelationsCount {
@@ -47,6 +47,7 @@ type Idea {
   categories: [Category!]
   favorites: [IdeaFavorite!]
   favoritesCount: Int
+  isMyFavorite: Boolean
   _count: IdeaRelationsCount
   id: Int!
   authorId: Int!

--- a/backend/src/schema.gql
+++ b/backend/src/schema.gql
@@ -14,6 +14,15 @@ A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date
 """
 scalar DateTime
 
+type IdeaFavorite {
+  user: User
+  idea: Idea
+  id: Int!
+  userId: Int!
+  ideaId: Int!
+  createdAt: DateTime!
+}
+
 type IdeaCategory {
   category: Category
   id: Int!
@@ -26,6 +35,7 @@ type IdeaCategory {
 type IdeaRelationsCount {
   comments: Int!
   reports: Int!
+  favorites: Int!
 }
 
 type Idea {
@@ -35,6 +45,8 @@ type Idea {
   reportsCount: Int
   ideaCategories: [IdeaCategory!]
   categories: [Category!]
+  favorites: [IdeaFavorite!]
+  favoritesCount: Int
   _count: IdeaRelationsCount
   id: Int!
   authorId: Int!
@@ -62,6 +74,7 @@ type UserRelationsCount {
   ideas: Int!
   comments: Int!
   reports: Int!
+  ideaFavorites: Int!
 }
 
 type User {
@@ -70,6 +83,9 @@ type User {
   comments: [Comment!]
   commentsCount: Int
   reportsCount: Int
+  ideaFavorites: [IdeaFavorite!]
+  favoriteIdeas: [Idea!]
+  favoriteIdeasCount: Int
   _count: UserRelationsCount
   id: Int!
   email: String!
@@ -108,6 +124,8 @@ type Mutation {
   updateUserProfile(userProfileUpdateInput: UserProfileUpdateInput!): User!
   deleteUser: Boolean!
   createComment(commentCreateInput: CommentCreateInput!): Comment!
+  createIdeaFavorite(ideaId: Int!): IdeaFavorite!
+  deleteIdeaFavorite(ideaId: Int!): Boolean!
   createIdea(ideaCreateInput: IdeaCreateInput!): Idea!
   deleteIdea(id: Int!): Boolean!
 }

--- a/backend/src/user/constants/user.constant.ts
+++ b/backend/src/user/constants/user.constant.ts
@@ -71,4 +71,70 @@ export const FIELD_RELATIONS: Array<{
       },
     },
   },
+  {
+    field: 'favoriteIdeas',
+    relations: {
+      ideaFavorites: {
+        include: {
+          idea: {
+            include: {
+              author: true,
+              ideaCategories: {
+                include: {
+                  category: true,
+                },
+                orderBy: {
+                  category: {
+                    id: SORT_ORDER.asc,
+                  },
+                },
+              },
+              _count: {
+                select: {
+                  comments: {
+                    where: {
+                      deletedAt: null,
+                    },
+                  },
+                  favorites: {
+                    where: {
+                      idea: {
+                        deletedAt: null,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        where: {
+          idea: {
+            deletedAt: null,
+          },
+        },
+        orderBy: {
+          idea: {
+            createdAt: SORT_ORDER.desc,
+          },
+        },
+      },
+    },
+  },
+  {
+    field: 'favoriteIdeasCount',
+    relations: {
+      _count: {
+        select: {
+          ideaFavorites: {
+            where: {
+              idea: {
+                deletedAt: null,
+              },
+            },
+          },
+        },
+      },
+    },
+  },
 ]

--- a/backend/src/user/constants/user.constant.ts
+++ b/backend/src/user/constants/user.constant.ts
@@ -17,6 +17,41 @@ export const FIELD_RELATIONS: Array<{
         orderBy: {
           createdAt: SORT_ORDER.desc,
         },
+        include: {
+          author: true,
+          ideaCategories: {
+            include: {
+              category: true,
+            },
+            orderBy: {
+              category: {
+                id: SORT_ORDER.asc,
+              },
+            },
+          },
+          favorites: {
+            where: {
+              // 利用するときにuserIdを置換する処理が必要
+              userId: '%userId%' as unknown as number,
+            },
+          },
+          _count: {
+            select: {
+              comments: {
+                where: {
+                  deletedAt: null,
+                },
+              },
+              favorites: {
+                where: {
+                  idea: {
+                    deletedAt: null,
+                  },
+                },
+              },
+            },
+          },
+        },
       },
     },
   },

--- a/backend/src/user/models/user.model.ts
+++ b/backend/src/user/models/user.model.ts
@@ -2,6 +2,7 @@ import { Field, HideField, Int, ObjectType } from '@nestjs/graphql'
 
 import { Comment } from '@src/comment/models/comment.model'
 import { Idea } from '@src/idea/models/idea.model'
+import { IdeaFavorite } from '@src/ideaFavorite/models/ideaFavorite.model'
 
 @ObjectType()
 export class UserRelationsCount {
@@ -13,6 +14,9 @@ export class UserRelationsCount {
 
   @Field(() => Int)
   reports?: number
+
+  @Field(() => Int)
+  ideaFavorites?: number
 }
 
 @ObjectType()
@@ -31,6 +35,15 @@ export class UserRelations {
 
   @Field(() => Int, { nullable: true })
   reportsCount?: number | null
+
+  @Field(() => [IdeaFavorite], { nullable: true })
+  ideaFavorites?: IdeaFavorite[] | null
+
+  @Field(() => [Idea], { nullable: true })
+  favoriteIdeas?: Idea[] | null
+
+  @Field(() => Int, { nullable: true })
+  favoriteIdeasCount?: number | null
 
   @Field(() => UserRelationsCount, { nullable: true })
   _count?: UserRelationsCount | null

--- a/backend/src/user/user.resolver.ts
+++ b/backend/src/user/user.resolver.ts
@@ -16,7 +16,7 @@ export class UserResolver {
   @Query(() => User)
   @UseGuards(JwtAuthGuard)
   async user(@RequestedFields() requestedFields: string[], @AuthenticatedUser() user: User): Promise<User> {
-    const relations = this.userService.createRelations(requestedFields)
+    const relations = this.userService.createRelations(requestedFields, this.userService.FIELD_RELATIONS, user.id)
     const resource = await this.userService.getById(user.id, relations)
 
     if (!resource) {


### PR DESCRIPTION
## 概要
- お気に入り一覧を追加
- お気に入り数を追加
- 自分のお気に入りかのプロパティも追加
- お気に入りは物理削除のため、`backend/src/prisma/prisma.service.ts`の`softDeleteWithRelations`を`deleteWithRelations`に変更し、論理削除のRelationsと物理削除のRelationsの両方に対応