### PR TITLE
[Data Loader対応] userのideasとcommentsをスキーマ通りにリクエストできるようにした

### DIFF
--- a/backend/src/comment/comment.module.ts
+++ b/backend/src/comment/comment.module.ts
@@ -7,5 +7,6 @@ import { CommentService } from './comment.service'
 @Module({
   imports: [PrismaModule],
   providers: [CommentService, CommentResolver],
+  exports: [CommentService],
 })
 export class CommentModule {}

--- a/backend/src/comment/comment.service.ts
+++ b/backend/src/comment/comment.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common'
 import { PrismaService } from '@src/prisma/prisma.service'
 
+import { SORT_ORDER } from '@src/common/constants/sortOrder.constant'
 import { CommentCreateInput } from './dto/commentCreate.input'
 import { Comment } from './models/comment.model'
 
@@ -16,5 +17,24 @@ export class CommentService {
         authorIp: Buffer.from(authorIp),
       },
     })
+  }
+
+  async listByIdeaId(ideaId: number): Promise<Comment[]> {
+    const resources = await this.prismaService.client.idea
+      .findUnique({
+        where: {
+          id: ideaId,
+        },
+      })
+      .comments({
+        where: {
+          deletedAt: null,
+        },
+        orderBy: {
+          createdAt: SORT_ORDER.desc,
+        },
+      })
+
+    return resources ?? []
   }
 }

--- a/backend/src/idea/dto/ideasGet.args.ts
+++ b/backend/src/idea/dto/ideasGet.args.ts
@@ -25,7 +25,10 @@ export class IdeasGetArgs {
   @ArrayNotEmpty()
   @IsOrderByFieldValid(['id', 'title', 'content', 'openLevel', 'createdAt', 'updatedAt'])
   orderBy?: OrderByArgs[]
+}
 
+@ArgsType()
+export class IdeasGetArgsExtended extends IdeasGetArgs {
   @Field(() => Boolean, { nullable: true })
   @IsOptional()
   includeReportedBySelf?: boolean

--- a/backend/src/idea/idea.module.ts
+++ b/backend/src/idea/idea.module.ts
@@ -1,11 +1,13 @@
 import { Module } from '@nestjs/common'
 
+import { CommentModule } from '@src/comment/comment.module'
 import { PrismaModule } from '@src/prisma/prisma.module'
 import { IdeaResolver } from './idea.resolver'
 import { IdeaService } from './idea.service'
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, CommentModule],
   providers: [IdeaService, IdeaResolver],
+  exports: [IdeaService],
 })
 export class IdeaModule {}

--- a/backend/src/schema.gql
+++ b/backend/src/schema.gql
@@ -14,6 +14,48 @@ A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date
 """
 scalar DateTime
 
+type UserRelationsCount {
+  ideas: Int!
+  comments: Int!
+  reports: Int!
+}
+
+type User {
+  ideas(title: String, content: String, openLevel: Int, orderBy: [OrderByArgs!]): [Idea!]!
+  ideasCount: Int
+  comments: [Comment!]
+  commentsCount: Int
+  reportsCount: Int
+  _count: UserRelationsCount
+  id: Int!
+  email: String!
+  username: String!
+  nickname: String
+  profileImage: String
+  age: Int
+  emailVerifiedAt: DateTime
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  deletedAt: DateTime
+}
+
+input OrderByArgs {
+  field: String!
+  order: String!
+}
+
+type Comment {
+  author: User
+  idea: Idea
+  id: Int!
+  ideaId: Int!
+  authorId: Int!
+  content: String!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  deletedAt: DateTime
+}
+
 type IdeaCategory {
   category: Category
   id: Int!
@@ -46,43 +88,6 @@ type Idea {
   deletedAt: DateTime
 }
 
-type Comment {
-  author: User
-  idea: Idea
-  id: Int!
-  ideaId: Int!
-  authorId: Int!
-  content: String!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  deletedAt: DateTime
-}
-
-type UserRelationsCount {
-  ideas: Int!
-  comments: Int!
-  reports: Int!
-}
-
-type User {
-  ideas: [Idea!]
-  ideasCount: Int
-  comments: [Comment!]
-  commentsCount: Int
-  reportsCount: Int
-  _count: UserRelationsCount
-  id: Int!
-  email: String!
-  username: String!
-  nickname: String
-  profileImage: String
-  age: Int
-  emailVerifiedAt: DateTime
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  deletedAt: DateTime
-}
-
 type SignInResponse {
   accessToken: String!
   user: User!
@@ -90,15 +95,10 @@ type SignInResponse {
 
 type Query {
   user: User!
-  categories: [Category!]!
   ideas(title: String, content: String, openLevel: Int, orderBy: [OrderByArgs!], includeReportedBySelf: Boolean): [Idea!]
   ideasCount(title: String, content: String, openLevel: Int, orderBy: [OrderByArgs!], includeReportedBySelf: Boolean): Int!
   idea(id: Int!): Idea!
-}
-
-input OrderByArgs {
-  field: String!
-  order: String!
+  categories: [Category!]!
 }
 
 type Mutation {
@@ -107,9 +107,9 @@ type Mutation {
   requestEmailChange(emailChangeRequestInput: EmailChangeRequestInput!): Boolean!
   updateUserProfile(userProfileUpdateInput: UserProfileUpdateInput!): User!
   deleteUser: Boolean!
-  createComment(commentCreateInput: CommentCreateInput!): Comment!
   createIdea(ideaCreateInput: IdeaCreateInput!): Idea!
   deleteIdea(id: Int!): Boolean!
+  createComment(commentCreateInput: CommentCreateInput!): Comment!
 }
 
 input SignUpInput {
@@ -138,14 +138,14 @@ input UserProfileUpdateInput {
   age: Int
 }
 
-input CommentCreateInput {
-  ideaId: Int!
-  content: String!
-}
-
 input IdeaCreateInput {
   title: String!
   content: String!
   openLevel: Int
   categoryIds: [Int!]!
+}
+
+input CommentCreateInput {
+  ideaId: Int!
+  content: String!
 }

--- a/backend/src/user/models/user.model.ts
+++ b/backend/src/user/models/user.model.ts
@@ -17,8 +17,8 @@ export class UserRelationsCount {
 
 @ObjectType()
 export class UserRelations {
-  @Field(() => [Idea], { nullable: true })
-  ideas?: Idea[] | null
+  @Field(() => [Idea])
+  ideas?: Idea[]
 
   @Field(() => Int, { nullable: true })
   ideasCount?: number | null

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common'
 
+import { IdeaModule } from '@src/idea/idea.module'
 import { PrismaModule } from '@src/prisma/prisma.module'
 import { UserResolver } from './user.resolver'
 import { UserService } from './user.service'
 
 @Module({
-  imports: [PrismaModule],
-  providers: [UserResolver, UserService],
+  imports: [PrismaModule, IdeaModule],
+  providers: [UserService, UserResolver],
   exports: [UserService],
 })
 export class UserModule {}


### PR DESCRIPTION
## 概要
現状はスキーマ通りにGraphQLでリクエストしても、存在するはずの値がnullで返却されることがある。
これは意図した通りの挙動だが、クロスプラットフォームでUIが異なる場合や一般ユーザー向けにリリースする場合など、より柔軟に対応する必要があるときは、スキーマ通りに返却された方が良いため、本PRを参考に実装する。

## 詳細
現状は各フィールドに対するRelationをPrismaのinclude機能を使ってまとめてレスポンスしている。
そのためincludeに含めていないRelationをフィールドに渡すとエラーにはならず、nullがレスポンスされる。

例えばideas場合、以下のように`@Parent`デコレータを使うことで、Ideaエンティティの親データ（この場合はideaオブジェクト）を受け取ることが可能になる。これでPrismaのinclude機能を使わずに、スキーマ通りにレスポンスすることが可能になる。
``` ts
@ResolveField(() => [Comment])
  async comments(@Parent() idea: Idea): Promise<Comment[]> {
    return await this.commentService.listByIdeaId(idea.id)
}
```

## Prismaのinclude機能を使ってレスポンスしている理由
- UIはWebブラウザの1つのみで、ある程度リクエスト内容が決まっているため
- 実装コストが低いため
ただしエンティティが増えれば増えるほど本PRのような方法のほうが実装コストが低くなる
- SQLがよりまとまって実行されてパフォーマンスが良いため

## スキーマ通りにレスポンスする際の課題
### N+1問題
Prismaの[Fluent API](https://www.prisma.io/docs/orm/prisma-client/queries/relation-queries#fluent-api)を使うことで、PrismaクライアントのPrismaデータローダーが`findUnique()`クエリなどをバッチ処理してくれる。Prismaを使用しない場合は[graphql/dataloader](https://github.com/graphql/dataloader)を使用するのが良さそう。