### PR TITLE
docs: Add Ant Design ConfigProvider documentation reference

### DIFF
--- a/frontend/app/themes/buttonClickEffect.ts
+++ b/frontend/app/themes/buttonClickEffect.ts
@@ -1,3 +1,5 @@
+// @see: https://ant.design/docs/blog/happy-work#configprovider
+
 import type { WaveConfig } from 'antd/lib/config-provider/context'
 
 const createHolder = (node: HTMLElement) => {


### PR DESCRIPTION
## Summary
- Add reference link to Ant Design's ConfigProvider documentation in buttonClickEffect.ts
- This helps developers understand how the custom button click effect relates to Ant Design's configuration options

## Test plan
- No functional changes, documentation only

🤖 Generated with [Claude Code](https://claude.ai/code)